### PR TITLE
%pにおけるINT_MAX,-ULONG_MAXのエラー対応

### DIFF
--- a/srcs/conversion_p.c
+++ b/srcs/conversion_p.c
@@ -6,7 +6,7 @@
 /*   By: yahokari <yahokari@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/11/13 11:08:34 by yahokari          #+#    #+#             */
-/*   Updated: 2024/01/19 09:44:22 by yahokari         ###   ########.fr       */
+/*   Updated: 2024/02/16 10:54:37 by yahokari         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,9 +14,12 @@
 
 void	print_conversion_p(t_vars *vars, t_flags *flags, uintptr_t p)
 {
+	size_t	len_hex_lower;
+
 	ft_putstr_fd(ALT_HEX_LOWER, STDOUT_FILENO);
-	vars->word_count += ft_strlen(ALT_HEX_LOWER);
-	if (flags->width >= num_len_in_str(p, HEX_LOWER))
-		flags->width -= num_len_in_str(p, HEX_LOWER);
+	len_hex_lower = ft_strlen(ALT_HEX_LOWER);
+	vars->word_count += len_hex_lower;
+	if (flags->width >= (int)len_hex_lower)
+		flags->width -= len_hex_lower;
 	print_unsigned(vars, flags, p, HEX_LOWER);
 }


### PR DESCRIPTION
%pにおいてアドレス出力の前に0xをつける処理を追加した際に，widthの調整を行ったが，その処理に誤りがあったため，0xの長さ分のみwidthを減らすよう修正した．